### PR TITLE
adds DVTPlugInCompatibilityUUID for Xcode 6.2

### DIFF
--- a/cocoadocs/CocoaPods-Info.plist
+++ b/cocoadocs/CocoaPods-Info.plist
@@ -32,6 +32,7 @@
 	<false/>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>


### PR DESCRIPTION
#51 - adds support for latest Xcode version.