### PR TITLE
Xcode 6.3.2 Menu support

### DIFF
--- a/cocoadocs/CocoaPods.m
+++ b/cocoadocs/CocoaPods.m
@@ -75,7 +75,9 @@ static NSString* const XAR_EXECUTABLE = @"/usr/bin/xar";
     if (self = [super init]) {
         _bundle = plugin;
         [self loadCustomGemPath];
-        [self addMenuItems];
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            [self addMenuItems];
+        }];
     }
     return self;
 }


### PR DESCRIPTION
Fixed so it did not appear in the menu of Xcode 6.3.2
https://github.com/kattrali/cocoapods-xcode-plugin/issues/62